### PR TITLE
Enhanced labeler

### DIFF
--- a/rlhfalife/data_managers.py
+++ b/rlhfalife/data_managers.py
@@ -410,6 +410,10 @@ class PairsManager:
         """Get all ranked pairs (where winner is not null)."""
         return self.pairs_df[self.pairs_df['winner'].notnull()].reset_index(drop=True).copy()
     
+    def unranked_pairs_iterator(self) -> Iterator[Tuple[str, str]]:
+        """Get an iterator over all unranked pairs."""
+        return self._get_unranked_pairs()[['hash1', 'hash2']].itertuples(index=False, name=None)
+
     def set_winner(self, hash1: str, hash2: str, winner: float):
         """
         Set the winner for a pair.

--- a/rlhfalife/labeler.py
+++ b/rlhfalife/labeler.py
@@ -75,11 +75,9 @@ class VideoLabelerApp:
         self.progress_frame.pack(pady=5)
 
         # Add progress bars to the new frame
-        self.left_progress = ttk.Progressbar(self.progress_frame, orient="horizontal", length=200, mode="determinate")
-        self.left_progress.pack(side="left", padx=5)
-
-        self.right_progress = ttk.Progressbar(self.progress_frame, orient="horizontal", length=200, mode="determinate")
-        self.right_progress.pack(side="right", padx=5)
+        self.progress = ttk.Progressbar(self.progress_frame, orient="horizontal", length=200, mode="determinate")
+        self.progress.pack(padx=5)
+        self.progress['value'] = 0
 
         # Add pair info label
         self.pair_info_frame = tk.Frame(self.master)
@@ -163,6 +161,9 @@ class VideoLabelerApp:
         # Update the pair info label
         self.pair_info_label.config(text=f"Pair {self.pairs_manager.get_nb_ranked_pairs()} of {self.pairs_manager.get_nb_pairs()}: {self.hash1} vs {self.hash2}")
         
+        self.progress['value'] = 0
+        self.progress['maximum'] = self.cap1.get(cv2.CAP_PROP_FRAME_COUNT)
+
         # Start playing the videos
         self.play_videos()
 
@@ -241,6 +242,8 @@ class VideoLabelerApp:
             self.right_video_label.config(image=photo2)
             self.right_video_label.image = photo2
             
+            self.progress['value'] = self.cap1.get(cv2.CAP_PROP_POS_FRAMES)
+
             # Schedule the next frame update
             self.after_id = self.master.after(33, self.update_frames)  # ~30 fps
         else:

--- a/rlhfalife/labeler.py
+++ b/rlhfalife/labeler.py
@@ -44,7 +44,8 @@ class VideoLabelerApp:
         self.pairs_manager = pairs_manager
         self.verbose = verbose
         self.frame_size = frame_size
-        
+
+        self.is_playing = True
         self.master = master
         self.after_id = None
         self.cap1 = None
@@ -78,6 +79,10 @@ class VideoLabelerApp:
         self.progress = ttk.Progressbar(self.progress_frame, orient="horizontal", length=200, mode="determinate")
         self.progress.pack(padx=5)
         self.progress['value'] = 0
+
+        # Add play/pause button
+        self.play_pause_button = tk.Button(self.progress_frame, text="Play/Pause", command=self.toggle_play_pause)
+        self.play_pause_button.pack(side="left", padx=5)
 
         # Add pair info label
         self.pair_info_frame = tk.Frame(self.master)
@@ -124,6 +129,12 @@ class VideoLabelerApp:
         # Add a label to display keybindings
         self.keybindings_label = tk.Label(self.keybindings_frame, text="Keybindings:\nLeft Arrow: Left Wins\nRight Arrow: Right Wins\nDown Arrow: Equal\nSpace: Restart Videos\nBackspace: Previous Pair", justify="left")
         self.keybindings_label.pack()
+
+    def toggle_play_pause(self):
+        """Toggle the playing state of the videos."""
+        self.is_playing = not self.is_playing
+        if self.is_playing:
+            self.update_frames()
 
     def bind_keys(self):
         self.master.bind('<Left>', lambda event: self.left_wins())
@@ -204,6 +215,9 @@ class VideoLabelerApp:
 
     def update_frames(self):
         """Update the video frames."""
+        if not self.is_playing:
+            return
+        
         ret1, frame1 = self.cap1.read()
         ret2, frame2 = self.cap2.read()
 

--- a/rlhfalife/labeler.py
+++ b/rlhfalife/labeler.py
@@ -42,6 +42,7 @@ class VideoLabelerApp:
         self.simulator = simulator
         self.dataset_manager = dataset_manager
         self.pairs_manager = pairs_manager
+        self.pairs_iterator = pairs_manager.unranked_pairs_iterator()
         self.verbose = verbose
         self.frame_size = frame_size
 
@@ -103,6 +104,9 @@ class VideoLabelerApp:
         self.right_button = tk.Button(self.button_frame, text="Right Wins", command=self.right_wins)
         self.right_button.pack(side="left", padx=2)
 
+        self.skip_button = tk.Button(self.button_frame, text="Skip", command=self.skip_pair)
+        self.skip_button.pack(side="left", padx=2)
+
         self.generate_button = tk.Button(self.button_frame, text="Generate New Pairs", command=self.generate_new_pairs_dialog)
         self.generate_button.pack(side="left", padx=5)
 
@@ -143,13 +147,13 @@ class VideoLabelerApp:
         self.master.bind('<Down>', lambda event: self.declare_equal())
         self.master.bind('<space>', lambda event: self.restart_videos())
         self.master.bind('<BackSpace>', lambda event: self.previous_pair())
-
+        self.master.bind('<s>', lambda event: self.skip_pair())
     def load_next_videos(self, undo: bool = False):
         """Display the current pair of videos."""
         if undo:
             self.hash1, self.hash2 = self.pairs_manager.get_last_ranked_pair()
         else:
-            self.hash1, self.hash2 = self.pairs_manager.get_next_unranked_pair()
+            self.hash1, self.hash2 = next(self.pairs_iterator)
         if self.hash1 is None or self.hash2 is None:
             self.prompt_generate_new_pairs()
             return
@@ -310,6 +314,9 @@ class VideoLabelerApp:
 
     def declare_equal(self):
         self.record_winner('equal')
+
+    def skip_pair(self):
+        self.load_next_videos()
 
     def record_winner(self, winner):
         """Record the winner of the current pair."""

--- a/rlhfalife/labeler.py
+++ b/rlhfalife/labeler.py
@@ -107,6 +107,9 @@ class VideoLabelerApp:
         self.skip_button = tk.Button(self.button_frame, text="Skip", command=self.skip_pair)
         self.skip_button.pack(side="left", padx=2)
 
+        self.undo_button = tk.Button(self.button_frame, text="Undo", command=self.previous_pair)
+        self.undo_button.pack(side="left", padx=2)
+
         self.generate_button = tk.Button(self.button_frame, text="Generate New Pairs", command=self.generate_new_pairs_dialog)
         self.generate_button.pack(side="left", padx=5)
 

--- a/rlhfalife/quad_labeler.py
+++ b/rlhfalife/quad_labeler.py
@@ -384,6 +384,8 @@ class QuadLabelerApp:
             self.progress['value'] = current_frame
             self.progress_after_id = self.master.after(100, self.update_progress_bar)
         else:
+            if self.progress_after_id:
+                self.master.after_cancel(self.progress_after_id)
             self.progress_after_id = None
 
     def on_progress_click(self, event):

--- a/rlhfalife/quad_labeler.py
+++ b/rlhfalife/quad_labeler.py
@@ -472,7 +472,7 @@ class QuadLabelerApp:
                         return result
             return None
 
-        all_hashes_sorted = [h for h, _ in sorted(hash_rankings.items(), key=lambda x: x[1])]
+        all_hashes_sorted = [h for h, _ in sorted(hash_rankings.items(), key=lambda x: (x[1], np.random.randint(100)))]
         
         best_hashes = _find_next_quad(all_hashes_sorted, [], self.ignored_quads, existing_pairs_set)
 


### PR DESCRIPTION
Improve the pair and quad labelers.  

- [x] Address #7 for better controls on the videos   
  - Add a play/pause button  
  - Add an interactive progress bar to select the frame to display  
- [x] Address #5 to be able to skip a pair  
  - Add "ignored tuples". Equivalent to "rankings skipped". 
  - Change the way tuples are selected with a DFS based on number of rankings a hash has. More robust, fair and compatible with ignored tuples.
  - Note: this skipping is a shallow one. If you restart a labeling session, all past ignored tuples will show up again.   
- [x] Address #6 to be able to undo a ranking in the quad labeler  
  - Pairs labeler is left almost unchanged, since it had the feature already
  - Quad labeler has now a ranking history, when user undo it is simply popped, not erasing the ranking done. But upon making a new ranking, it overrides the previous one