### PR TITLE
Enhance live benchmarking

### DIFF
--- a/rlhfalife/benchmarker.py
+++ b/rlhfalife/benchmarker.py
@@ -14,10 +14,11 @@ from pathlib import Path
 class LiveBenchmarkApp:
     """App for live benchmarking with auto-generated simulations and rewarder scoring."""
     
-    def __init__(self, master: tk.Toplevel, simulator: Simulator, generator: Generator, 
+    def __init__(self, master: tk.Toplevel, number_of_videos: int, simulator: Simulator, generator: Generator, 
                  rewarder: Rewarder, out_paths: dict, frame_size: tuple = (300, 300),
                  on_close=None) -> None:
         self.master = master
+        self.number_of_videos = number_of_videos
         self.simulator = simulator
         self.generator = generator
         self.rewarder = rewarder
@@ -90,7 +91,7 @@ class LiveBenchmarkApp:
         if self._is_closing: return
         self.update_status("Generating parameters...")
         try:
-            self.params = self.generator.generate(10)
+            self.params = self.generator.generate(self.number_of_videos)
         except Exception as e:
             print(f"Error during parameter generation: {e}")
             self.update_status("Error during generation.") # update_status will check _is_closing
@@ -103,7 +104,7 @@ class LiveBenchmarkApp:
             print("!!! WARNING !!!: Generator generated at least two identical parameters.")
             # Filter out the identical parameters
             self.params = [self.params[i] for i in range(len(self.params)) if not any(str(self.params[i]) == str(self.params[j]) for j in range(i+1, len(self.params)))]
-            print(f"Unique parameters: {len(self.params)}, over 10 generated.")
+            print(f"Unique parameters: {len(self.params)}, over {self.number_of_videos} generated.")
             print("="*50 + "\n")
         if self._is_closing: return
 
@@ -1292,6 +1293,9 @@ def launch_benchmarker(simulator: Simulator, generator: Generator, rewarder: Rew
     choice = input("Choose an option: ")
 
     if choice == '1':
+        number_of_videos = input("Enter the number of simulations that will be used: ")
+        number_of_videos = int(number_of_videos)
+
         print("Launching Live Benchmark GUI...")
         root = tk.Tk()
         root.withdraw() # Hide the root window
@@ -1300,6 +1304,7 @@ def launch_benchmarker(simulator: Simulator, generator: Generator, rewarder: Rew
             root.destroy()
         live_app = LiveBenchmarkApp(
             tk.Toplevel(root),
+            number_of_videos,
             simulator,
             generator,
             rewarder,

--- a/rlhfalife/benchmarker.py
+++ b/rlhfalife/benchmarker.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import messagebox, ttk
+from tkinter import messagebox, ttk, filedialog, simpledialog
 import threading
 import cv2
 from PIL import Image, ImageTk
@@ -272,17 +272,17 @@ class LiveBenchmarkApp:
             messagebox.showinfo("Info", "No videos available to save.")
             return
 
-        from tkinter import filedialog
-        snapshot_path_str = filedialog.asksaveasfilename(
-            title="Save Benchmark Snapshot As",
+        snapshot_path_str = filedialog.askdirectory(
+            title="Save Benchmark Snapshot In",
             initialdir=str(Path(self.out_paths.get('root', '.')) / "benchmarks"),
-            defaultextension="",
         )
+
+        snapshot_name = simpledialog.askstring("Save Benchmark Snapshot As", "Enter the name of the snapshot: ")
 
         if not snapshot_path_str:
             return
 
-        snapshot_path = Path(snapshot_path_str)
+        snapshot_path = Path(snapshot_path_str) / snapshot_name
         
         should_overwrite = False
         if snapshot_path.exists():


### PR DESCRIPTION
Provide minor enhancements to live benchmarking.

- [x] Address #8   
  - Add a simple prompt before the launch of the `LiveBenchmarkApp`   
- [x] Address #12 
  - Add a button to save benchmark
  - Ask user for destination
  - Saves the benchmark videos as `<rank>_score_<rounded_score>.mp4`, as well as the parameters (in another directory)